### PR TITLE
Catch malformed URI Components on parseQueryString

### DIFF
--- a/querystring/parse.js
+++ b/querystring/parse.js
@@ -8,7 +8,12 @@ module.exports = function(string) {
 	for (var i = 0; i < entries.length; i++) {
 		var entry = entries[i].split("=")
 		var key = decodeURIComponent(entry[0])
-		var value = entry.length === 2 ? decodeURIComponent(entry[1]) : ""
+		var value = "";
+		try{
+			value = entry.length === 2 ? decodeURIComponent(entry[1]) : "" 
+		}catch(err){
+			value = entry.length === 2 ? entry[1] : ""
+		}
 
 		if (value === "true") value = true
 		else if (value === "false") value = false


### PR DESCRIPTION
Fix for error thrown when a value contains non-valid / malformed URI Component
Example: test=%c5%a1%e8ZM%80%82H
will throw "URI malformed"
This update will leave the value as-is when an error is thrown