### PR TITLE
fix formatting of parse.js

### DIFF
--- a/querystring/parse.js
+++ b/querystring/parse.js
@@ -9,9 +9,9 @@ module.exports = function(string) {
 		var entry = entries[i].split("=")
 		var key = decodeURIComponent(entry[0])
 		var value = "";
-		try{
+		try {
 			value = entry.length === 2 ? decodeURIComponent(entry[1]) : "" 
-		}catch(err){
+		} catch(err) {
 			value = entry.length === 2 ? entry[1] : ""
 		}
 


### PR DESCRIPTION
fixed space formatting for merge request

## Description
Fix for error thrown when a value contains non-valid / malformed URI Component

## Motivation and Context
Example: test=%c5%a1%e8ZM%80%82H
will throw "URI malformed"

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change



## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/changelog.md`

This update will leave the value as-is when an error is thrown

